### PR TITLE
ConsentCookie init not waiting for DOM to be complete

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -49,9 +49,10 @@ function init($config) {
       'ConsentCookie already initialized. Visit: ' + DEFAULT_INFO_LINK + ' for more information.');
   }
 
-  initBaseView();
-  initVue($config);
-  return true;
+  return onReady(() => {
+    initBaseView();
+    initVue($config);
+  });
 }
 
 function initBaseView() {
@@ -82,6 +83,14 @@ function initVue($config) {
   }).$mount('#ConsentCookie');
 }
 
+function onReady($fn) {
+  if (document.readyState === 'interactive') {
+    $fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', $fn);
+  }
+}
+
 function off($event, $callback) {
   if (!mainInstance) {
     return utils.logErrorOrThrowException('Unable to unregister event. ConsentCookie is not yet initialized.');
@@ -96,7 +105,7 @@ function on($event, $callback) {
   return mainInstance.$events.$on($event, $callback);
 }
 
-function get($id){
+function get($id) {
   return mainInstance.$services.consent.get($id);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description
<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
In the init ConsentCookie is added to the body element. If you place the script responsible for the init in the ```<head>``` of the page it will cause an error

## Expected Behavior
<!--- Tell us what should happen -->
ConsentCookie will not cause an error and is initialised when adding ConsentCookie script to the ```<head>```

## Actual Behavior
<!--- Tell us what happens instead -->
ConsentCookie cause an error and is not initialised when adding ConsentCookie script to the ```<head>```

## Possible Fix
<!--- Not obligatory, but suggest a fix or reason for the bug -->
no applic

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. Create HTML page with the following
```html
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="nl" lang="nl">
<head>
    <script src="latest/consentcookie.min.js"></script>
    <script type="application/javascript">
        ConsentCookie.init({
            'connections': {},
            'moreinfolink': ""
        });
    </script>
</head>
<body>
</body>
</html>
```
2. Load the just created page

## Context
<!--- How has this bug affected you? What were you trying to accomplish? -->
Loading ConsentCookie from the ```<head>```

## Your Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Version used: master
* Browser Name and version: all
* Operating System and version (desktop or mobile): all
* Link to your project:
