### PR TITLE
fix: replace name howto with about

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -72,7 +72,7 @@
     },
     'resources': {
       'nl': {
-        'info': {
+        'about': {
           'title': '',
           'text': ''
         },

--- a/src/components/main/icMenu.vue
+++ b/src/components/main/icMenu.vue
@@ -53,7 +53,7 @@
   }, {
     icon: 'help',
     iconSize: '30',
-    path: '/howto',
+    path: '/about',
     info: 'Over ConsentCookie',
   }];
 

--- a/src/config/configRouter.js
+++ b/src/config/configRouter.js
@@ -115,8 +115,8 @@ function configRouter(vue) {
       path: DEFAULT_PATH_CONSENT,
       component: require('views/consent.vue'),
     }, {
-      path: '/howto',
-      component: require('views/howto.vue'),
+      path: '/about',
+      component: require('views/about.vue'),
     }, {
       path: '/connections',
       component: require('views/connections.vue'),

--- a/src/views/about.vue
+++ b/src/views/about.vue
@@ -18,8 +18,8 @@
 <template>
   <div class="howto">
     <ic-content-box>
-      <div class="icText" v-show="info" v-html="info"/>
-      <div v-show="!info">
+      <div class="icText" v-show="about" v-html="about"/>
+      <div v-show="!about">
         <div class="icText intro">
           Baas over eigen data, dat vinden wij heel normaal. Niet alleen vanwege de AVG, maar omdat wij geloven in
           transparantie en fatsoen. Daarom gebruiken wij ConsentCookie.
@@ -47,8 +47,8 @@
   const icVideo = require('components/general/icVideo.vue');
 
   // Defaults
-  const DEFAULT_CONFIG_KEY_RESOURCES_NL_INFO_TITLE = 'resources.nl.info.title';
-  const DEFAULT_CONFIG_KEY_RESOURCES_NL_INFO_TEXT = 'resources.nl.info.text';
+  const DEFAULT_CONFIG_KEY_RESOURCES_NL_ABOUT_TITLE = 'resources.nl.about.title';
+  const DEFAULT_CONFIG_KEY_RESOURCES_NL_ABOUT_TEXT = 'resources.nl.about.text';
 
   const DEFAULT_VIEW_TITLE = 'Over ConsentCookie';
 
@@ -61,10 +61,10 @@
     },
     computed: {
       title() {
-        return this.$services.config.get(DEFAULT_CONFIG_KEY_RESOURCES_NL_INFO_TITLE, DEFAULT_VIEW_TITLE);
+        return this.$services.config.get(DEFAULT_CONFIG_KEY_RESOURCES_NL_ABOUT_TITLE, DEFAULT_VIEW_TITLE);
       },
-      info() {
-        return this.$services.config.get(DEFAULT_CONFIG_KEY_RESOURCES_NL_INFO_TEXT);
+      about() {
+        return this.$services.config.get(DEFAULT_CONFIG_KEY_RESOURCES_NL_ABOUT_TEXT);
       },
     },
     methods: {},


### PR DESCRIPTION
For the how to page, we used 2 separate names: info and howto.

Due to incorrect naming of the feature, renamed it about.