### PR TITLE
eager plugin loading

### DIFF
--- a/src/services/applicationsService.js
+++ b/src/services/applicationsService.js
@@ -61,6 +61,8 @@ class ApplicationList {
     this.memoizedGetActive = _.memoize(this.getActive);
     this.memoizedGetActiveGroupedByPurpose = _.memoize(this.getActiveGroupedByPurpose);
     this.memoizedGetPurposes = _.memoize(this.getPurposes);
+
+    this.memoizedGetActive().forEach(application => hasPlugin(application));
   }
 
   get($id) {

--- a/src/services/pluginService.js
+++ b/src/services/pluginService.js
@@ -74,25 +74,6 @@ function init(vueServices) {
   vue = vueServices.getVueInstance();
 }
 
-function createAsyncScriptTag($uniqueId, $path, $callback) {
-  const scriptTag = window.document.createElement('script');
-  scriptTag.id = $uniqueId;
-  scriptTag.src = $path;
-  scriptTag.async = 'true';
-  scriptTag.addEventListener('load', function () {
-    $callback(this);
-  });
-  return scriptTag;
-}
-
-function cleanupScriptTag($id) {
-  const scriptTag = window.document.getElementById($id);
-  if (scriptTag && scriptTag.remove) {
-    // No support for IE. Its nice to have
-    scriptTag.remove();
-  }
-}
-
 function loadPlugin($id, $src) {
   return new Promise(($resolve, $reject) => {
     const uniqueId = ($id + '_' + new Date().getTime());


### PR DESCRIPTION
Plugins were only loaded when expanding a purpose group. This with the effect that toggling the consent switch did not trigger plugin code.
Now plugins are loaded when active applications are known.