### PR TITLE
Script cc id multiple ids

### DIFF
--- a/src/services/consentService.js
+++ b/src/services/consentService.js
@@ -39,6 +39,10 @@ class Consents {
     return _.filter(this.get(), ($consent => $consent.isAlwaysOn()));
   }
 
+  getEnabled() {
+    return _.filter(this.get(), ($consent => $consent.isEnabled()));
+  }
+
   add($consent) {
     if ($consent instanceof Consent) {
       this.getConsentMap()[$consent.id] = $consent;

--- a/src/services/scriptService.js
+++ b/src/services/scriptService.js
@@ -32,27 +32,28 @@ function init($vueServices) {
   vue = $vueServices.getVueInstance();
 }
 
-function findConsentScriptFilter($element, $consentId) {
+function isConsentScriptFilter($element, $consentId) {
   if (!($element instanceof Element) || !$consentId) {
     return false;
   }
-  const ccId = $element.getAttribute(SCRIPT_ELEMENT_ATTRIBUTE_CC_ID);
-
-  if (_.isEmpty(_.trim(ccId))) {
+  const ccIdElem = $element.getAttribute(SCRIPT_ELEMENT_ATTRIBUTE_CC_ID);
+  if (_.isEmpty(_.trim(ccIdElem))) {
     return false;
   }
 
+  const ccIds = ccIdElem.split(',').map(ccId => ccId.trim());
+
   if (_.isString($consentId)) {
-    return $consentId === ccId;
+    return _.contains(ccIds, $consentId);
   }
   if (_.isArray($consentId)) {
-    return _.contains($consentId, ccId);
+    return _.intersection($consentId, ccIds).length === ccIds.length;
   }
   return false;
 }
 
 function getScriptElements($consentId) {
-  return utils.getElementsByTagName('script', $element => findConsentScriptFilter($element, $consentId));
+  return utils.getElementsByTagName('script', $element => isConsentScriptFilter($element, $consentId));
 }
 
 function enableScript($element) {
@@ -106,9 +107,9 @@ function enableScripts($consentId) {
 }
 
 function enableOptOutScripts() {
-  const optOutConsentIds = _.map(vue.$services.consent.getConsents()
-    .getAccepted(), $consent => $consent.id);
-  enableScripts(optOutConsentIds);
+  const enabledConsentIds = _.map(vue.$services.consent.getConsents()
+    .getEnabled(), $consent => $consent.id);
+  enableScripts(enabledConsentIds);
 }
 
 function enableAlwaysOnScripts() {


### PR DESCRIPTION
## Problem
Application scripts, like the one for Google Analytics, can be turned off by default, by setting the `type` of the `script` tag to `text\plain` and adding the attribute `cc-id` to the tag with a value that matches its application id or purpose id. When ConsentCookie finds a matching consent, it will turn on the script. See also: https://www.consentcookie.nl/knowledgebase/integratie-van-consentcookie-met-trackingscripts/
Till now, only one `cc-id` value is possible. For example `cc-id="ccp-6"`. But what to do with applications that have multiple purposes? For this, we need multiple `cc-id` values.
## Solution
ConsentCookie now supports multiple `cc-id`'s. You can now add multiple values by separating them with a comma. For example: `cc-id="ccp-4,ccp-6"`. This means that this script will be turned on, only if both _ccp-4_ and _ccp-6_ consent are given.
