### PR TITLE
change libraryTarget from umd to window

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -45,7 +45,7 @@ module.exports = {
     path: config.build.assetsRoot,
     publicPath: process.env.NODE_ENV === 'production' ? config.build.assetsPublicPath : config.dev.assetsPublicPath,
     filename: '[name].js',
-    libraryTarget: 'umd',
+    libraryTarget: 'window',
     // the name exported to window
     library: 'ConsentCookie',
   },


### PR DESCRIPTION
When webpack `libraryTarget` equals `umd`, it will conflict with websites with RequireJS (AMD). We have seen errors like _See almond README: incorrect module build, no module name_. This can be fixed by only assigning the `ConsentCookie` to a `window` object.